### PR TITLE
Auto-Include of credentials.h

### DIFF
--- a/ReminderV2/ReminderV2.ino
+++ b/ReminderV2/ReminderV2.ino
@@ -36,7 +36,10 @@
 
 #include <ESP8266WiFi.h>
 #include "HTTPSRedirect.h"
-//#include <credentials.h>
+#if __has_include(<credentials.h>)
+#  include <credentials.h>
+#  define CREDENTIALS
+#endif
 
 
 

--- a/ReminderV2/credentials-example.h
+++ b/ReminderV2/credentials-example.h
@@ -1,0 +1,10 @@
+//Credentials File
+//Do not commit this file for your security!
+
+//WiFi Credentials
+#define mySSID = "............"
+#define myPASSWORD = "............"
+
+//Google Apps Script ID
+#define GoogleScriptIdRead = "............"
+#define GoogleScriptIdWrite = "............"

--- a/ReminderV2/credentials-example.h
+++ b/ReminderV2/credentials-example.h
@@ -1,4 +1,5 @@
 //Credentials File
+//To use this file rename this to credentials.h
 //Do not commit this file for your security!
 
 //WiFi Credentials


### PR DESCRIPTION
I like the way you handle keeping credentials private and still make the code useable by others.
To improve on this, the credentials.h file can be automatically included only if it exists. This uses __has_include with the compiler preprocessor.
I have also added an example credentials.h